### PR TITLE
fix: applied patch to use ~/PCem as config dir

### DIFF
--- a/src/wx-sdl2.c
+++ b/src/wx-sdl2.c
@@ -17,6 +17,12 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <math.h>
+
+#ifdef __APPLE__
+#include <sys/types.h>
+#include <sys/stat.h>
+#endif
+
 #include "ibm.h"
 #include "device.h"
 #include "cassette.h"
@@ -241,7 +247,22 @@ void get_pcem_path(char *s, int size)
 #ifdef __linux
         wx_get_home_directory(s);
         strcat(s, ".pcem/");
+
+#elif defined __APPLE__
+
+    wx_get_home_directory(s);
+    strcat(s, "PCem/");
+
+    struct stat st = {0};
+
+    // create ~/PCem/
+    // if it doesn't exist
+    if (stat(s, &st) == -1) {
+        mkdir(s, 0700);
+    }
 #else
+
+
         char* path = SDL_GetBasePath();
         strcpy(s, path);
 #endif


### PR DESCRIPTION
I've fixed the config path issue